### PR TITLE
Fix inconsistent Nova2 joint axes between cra_description and MoveIt URDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Build artifacts
+/build/
+/install/
+/log/
+/log_*/
+
+# Python
+__pycache__/
+*.py[cod]
+*.so
+*.egg-info/
+*.egg
+pip-wheel-metadata/
+
+# colcon / ament / cmake
+COLCON_IGNORE
+colcon_core/
+*.cmake
+CMakeCache.txt
+CMakeFiles/
+
+# IDE
+.vscode/
+.idea/
+
+# General
+*.swp
+*.tmp

--- a/cra_description/urdf/nova2_robot.xacro
+++ b/cra_description/urdf/nova2_robot.xacro
@@ -67,7 +67,7 @@
         <origin xyz="0 0 0.2234" rpy="0 0 0" />
         <parent link="base_link" />
         <child link="Link1" />
-        <axis xyz="0 0 -1" />
+        <axis xyz="0 0 1" />
         <limit lower="-6.28" upper="6.28" effort="300" velocity="100" />
     </joint>
     <link name="Link2">
@@ -160,7 +160,7 @@
         <origin xyz="-0.22501 0 0.1175" rpy="0 0 -1.5708" />
         <parent link="Link3" />
         <child link="Link4" />
-        <axis xyz="0 0 -1" />
+        <axis xyz="0 0 1" />
         <limit lower="-6.28" upper="6.28" effort="300" velocity="100" />
     </joint>
     <link name="Link5">
@@ -191,7 +191,7 @@
         <origin xyz="0 -0.12 0" rpy="1.5708 0 0" />
         <parent link="Link4" />
         <child link="Link5" />
-        <axis xyz="0 0 -1" />
+        <axis xyz="0 0 1" />
         <limit lower="-6.28" upper="6.28" effort="300" velocity="100" />
     </joint>
     <link name="Link6">


### PR DESCRIPTION
Summary                                                                    
This PR aligns the Nova2 joint axis definitions in `cra_description/urdf/nova2_robot.xacro` with the Nova2 URDF used by the      
MoveIt configuration in `dobot_rviz/urdf/nova2_robot.urdf`.

This PR changes these joints in:                                              
                                                                                
  ```text                                
  cra_description/urdf/nova2_robot.xacro                                        
                                     
  from:                                                                         
                                                                                
  <axis xyz="0 0 -1" />              
                                                                                
  to:                                                                           
                                     
  <axis xyz="0 0 1" />                                                          
                                                                                
  to match:                                                                     
                                                                                
  dobot_rviz/urdf/nova2_robot.urdf             
      
  for:                                                                          
                                                                                
  - joint1                                                                      
  - joint4                               
  - joint5                                                                      
                              
  Motivation                                                                    
                                         
  Currently, the Nova2 model has inconsistent joint axis definitions in different parts of the repository:                                            
                                                                                
  - nova2_moveit/config/nova2_robot.urdf.xacro includes dobot_rviz/urdf/nova2_robot.urdf                                              
  - dobot_gazebo loads cra_description/urdf/nova2_robot.xacro                   
                                                                                
  In dobot_rviz/urdf/nova2_robot.urdf, joint1, joint4, and joint5 use positive Z axes.                                 
                                                                                
  In cra_description/urdf/nova2_robot.xacro, the same joints use negative Z axes.                                                                         
                                                                                
  This can confuse developers and may cause MoveIt planning, Gazebo simulation, and external simulation backends to produce different forward kinematics results for the same joint trajectory.                                        
                                                                                
  Notes                     
                                                                                
  Please also consider checking other robot models in the repository for similar URDF inconsistencies, especially between:                                    
                                                                                
  - cra_description/urdf/                                                       
  - dobot_rviz/urdf/                                                            
  - *_moveit/config/      